### PR TITLE
Rename testing to edge

### DIFF
--- a/OpenMowerOS/src/modules/openmower/filesystem/root/boot/openmower/openmower_version.txt
+++ b/OpenMowerOS/src/modules/openmower/filesystem/root/boot/openmower/openmower_version.txt
@@ -1,8 +1,8 @@
 # select which version of the OpenMower software to run.
 #
-# - beta:     This one is the _most stable_ one of the three. I try to keep this as stable as possible.
-# - alpha:    For people who like to test stuff. This one will be updated fairly often as well and without notice. Only use it, if you want to be among the first people to get new features, but prepare to have issues.
-# - testing:  This one changes very often. Only use it if you want to take part in the development or are asked to use it by a developer.
+# - beta:   This one is the _most stable_ one of the three. I try to keep this as stable as possible.
+# - alpha:  For people who like to test stuff. This one will be updated fairly often as well and without notice. Only use it, if you want to be among the first people to get new features, but prepare to have issues.
+# - edge:   This one changes very often. Only use it if you want to take part in the development or are asked to use it by a developer.
 #
 # Check the https://github.com/ClemensElflein/open_mower_ros repo for the current state.
 


### PR DESCRIPTION
Noticed that currently [`releases-edge`](https://github.com/ClemensElflein/open_mower_ros/pkgs/container/open_mower_ros/110970996?tag=releases-edge) tag is being used to tag the latest version.

`releases-testing` has not been updated for the last 8 months:
<img width="260" alt="image" src="https://github.com/ClemensElflein/OpenMowerOS/assets/422086/ec936d4c-7c54-4ac6-89ac-cec008b94008">
