### PR TITLE
Do not remove container on service stop

### DIFF
--- a/OpenMowerOS/src/modules/openmower/filesystem/root/etc/systemd/system/openmower-debug.service
+++ b/OpenMowerOS/src/modules/openmower/filesystem/root/etc/systemd/system/openmower-debug.service
@@ -31,11 +31,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/container-openmower-debug.pid 
   --label io.containers.autoupdate=image \
   ghcr.io/clemenselflein/open_mower_ros:releases-${OM_VERSION}
 
-#ExecStartPost=/usr/bin/podman image prune --force --filter image=open_mower_ros
-
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/container-openmower-debug.ctr-id -t 10
-
-ExecStopPost=/usr/bin/podman rm --ignore --force --cidfile %t/container-openmower-debug.ctr-id
 
 PIDFile=%t/container-openmower-debug.pid
 

--- a/OpenMowerOS/src/modules/openmower/filesystem/root/etc/systemd/system/openmower.service
+++ b/OpenMowerOS/src/modules/openmower/filesystem/root/etc/systemd/system/openmower.service
@@ -35,10 +35,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/container-openmower.pid --cidf
   --label io.containers.autoupdate=registry \
   ghcr.io/clemenselflein/open_mower_ros:releases-${OM_VERSION}
 
-#ExecStartPost=/usr/bin/podman image prune --all --force
-
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/container-openmower.ctr-id -t 10
-ExecStopPost=/usr/bin/podman rm --ignore --force --cidfile %t/container-openmower.ctr-id
 PIDFile=%t/container-openmower.pid
 
 [Install]


### PR DESCRIPTION
It's annoying to get a container removed after it failed.

It immediately remove logs.  