### PR TITLE
Fix mosquitto chown noise

### DIFF
--- a/stage-openmower/40-openmower/files/opt/stacks/openmower/compose.yaml
+++ b/stage-openmower/40-openmower/files/opt/stacks/openmower/compose.yaml
@@ -33,6 +33,7 @@ services:
     image: eclipse-mosquitto:2
     container_name: Mosquitto
     restart: unless-stopped
+    user: mosquitto:mosquitto
     ports:
       - "1883:1883"
       - "9001:9001"


### PR DESCRIPTION
Will suppress some early container bootup warnings... for next release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Security hardening: The MQTT broker now runs as a non-root user inside its container, improving isolation and reducing risk.
  - No action required: Ports, volumes, and behavior are unchanged; deployment and operation remain fully backward-compatible.
  - Aligns the stack with least-privilege best practices for safer operation without impacting existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->