### PR TITLE
Update TESTED_FEATURES.md with HWv1 test results

### DIFF
--- a/TESTED_FEATURES.md
+++ b/TESTED_FEATURES.md
@@ -4,26 +4,26 @@ Legend: ✅ Pass · ❌ Fail · 🟡 Todo · 🔁 Retry · 🧪 Manual-only
 
 | Feature                                  | Expected                                  | HW‑V1<br>Pi4 | HW‑V2<br>CM4 | HW‑V2<br>CM5 |
 | ---------------------------------------- | ----------------------------------------- | :----------: | :----------: | :----------: |
-| Auto-reboot after initial boot           | yes, but seem to be a bug                 |      🟡       |      ❌🧪      |      🟡       |
-| Debian release `lsb_release -a`          | Debian GNU/Linux 13 (trixie)              |      🟡       |      ✅       |      🟡       |
-| OpenMowerOS release `cat /etc/rpi-issue` | OpenMowerOS v2.x YYYY-MM-DD               |      🟡       |      ✅       |      🟡       |
+| Auto-reboot after initial boot           | yes, but seem to be a bug                 |      ✅       |      ❌🧪      |      🟡       |
+| Debian release `lsb_release -a`          | Debian GNU/Linux 13 (trixie)              |      ✅       |      ✅       |      🟡       |
+| OpenMowerOS release `cat /etc/rpi-issue` | OpenMowerOS v2.x YYYY-MM-DD               |      ✅       |      ✅       |      🟡       |
 | Hostname (default) `hostname`            | openmower                                 |      🟡       |      ✅       |      🟡       |
-| Hostname (non- default) `hostname`       | <as set by imager>                        |      🟡       |      ✅       |      🟡       |
+| Hostname (non- default) `hostname`       | <as set by imager>                        |      ✅       |      ✅       |      🟡       |
 | Default user/password                    | openmower/openmower                       |      🟡       |      ✅       |      🟡       |
-| SSH enabled                              | SSH active on first boot                  |      🟡       |      ✅       |      🟡       |
+| SSH enabled                              | SSH active on first boot                  |      ✅       |      ✅       |      🟡       |
 | SSH public key                           | Password less SSH login via SSH-key       |      🟡       |      ✅       |      🟡       |
-| Imager Wi‑Fi                             | Preseeded Wi‑Fi connects on first boot    |      🟡       |      ✅       |      🟡       |
-| Imager openmower pass                    | Applied when configured                   |      🟡       |      ✅       |      🟡       |
+| Imager Wi‑Fi                             | Preseeded Wi‑Fi connects on first boot    |      ✅       |      ✅       |      🟡       |
+| Imager openmower pass                    | Applied when configured                   |      ✅       |      ✅       |      🟡       |
 | No known Wi‑Fi                           | Comitup AP appears (default SSID pattern) |      🟡       |      ✅       |      🟡       |
 | AP portal                                | Able to configure Wi‑Fi, then joins WLAN  |      🟡       |      ✅       |      🟡       |
-| Internal LAN                             | xCore is getting an IPv4                  |      🟡       |      ✅       |      🟡       |
+| Internal LAN                             | xCore is getting an IPv4                  |      --       |      ✅       |      🟡       |
 | Home LAN                                 | eth0 IPv4 by your networks DHCP           |      🟡       |      ✅       |      🟡       |
-| SSH                                      | Reachable after network is up             |      🟡       |      ✅       |      🟡       |
-| WebTerminal (ttyd)                       | Reachable at port 7681                    |      🟡       |      ✅       |      🟡       |
-| Dockge                                   | Reachable at port 5001                    |      🟡       |      ✅       |      🟡       |
-| ESC access                               | Ports get exposed via `openmower ...` cmd |      🟡       |      🟡       |      🟡       |
-| GNSS access                              | Port get exposed via `openmower ...` cmd  |      🟡       |      🟡       |      🟡       |
-| Container shell (prefix)                 | `openmower shell` has docker prefix       |      🟡       |      ✅       |      🟡       |
+| SSH                                      | Reachable after network is up             |      ✅       |      ✅       |      🟡       |
+| WebTerminal (ttyd)                       | Reachable at port 7681                    |      ✅       |      ✅       |      🟡       |
+| Dockge                                   | Reachable at port 5001                    |      ✅       |      ✅       |      🟡       |
+| ESC access                               | Ports get exposed via `openmower ...` cmd |      ✅       |      🟡       |      🟡       |
+| GNSS access                              | Port get exposed via `openmower ...` cmd  |      ✅       |      🟡       |      🟡       |
+| Container shell (prefix)                 | `openmower shell` has docker prefix       |      ✅       |      ✅       |      🟡       |
 
 ## Notes
 


### PR DESCRIPTION
I updated the test matrix according to the following test scenario

### Environment

-  HWv1
- OSv2 (OpenMowerOS_20250916.img)
- open_mower_ros: latest (I think sha-374264a)
- Yard Force Classic 500 with mainboard 0_11_X_WT901
- no NTRIP usage

### Test scenario

- Raspberry Pi Imager (v1.3.9) configuration
  - Hostname: \<myhostname\>
  - User: `openmower`
  - Pwd: \<mypassword\>
  - Wifi: \<myssid\>/\<mywifipassword\>
  - SSH: on with password
- first startup
  - I don't know if it booted twice but I didn't need to manually reboot => look ok to me
  - `ping <myhostname>` ok (after maybe 1min)
  - `ssh <myhostname>` ok
  - `lsb_release -a` => ok
```
      No LSB modules are available.
      Distributor ID: Debian
      Description:    Debian GNU/Linux 13 (trixie)
      Release:        13
      Codename:       trixie
```
  - OpenMower Release `cat /etc/rpi-issue` => ok
```
  OpenMowerOS v2.x 2025-10-16
  Generated using pi-gen, https://github.com/RPi-Distro/pi-gen, 7dadcf1fc5ce1648ab09409ab978831690c9a955, stage-openmower
```
- WebTerminal (ttyd)
  - http://\<myhostname\>:7681/
  - works, no password necessary
  - `openmower`command available
- Dockge
  - http://\<myhostname\>:5001/
  - works, no password necessary
  - configure openmower environment for v1 hardware:
    - `VERSION="latest"` → leave unchanged
    - `HARDWARE_PLATFORM=2` → `HARDWARE_PLATFORM=1`
    - `MOWER="CHANGE_ME"` → `MOWER="YardForce500"`
    - `FIRMWARE="CHANGE_ME"` → `FIRMWARE="0_11_X_WT901"`
    - save and start container
```
          [+] Running 38/38
           ✔ OpenMowerApp Pulled                12.0s 
           ✔ open_mower_ros Pulled             849.9s 
           ✔ Mosquitto Pulled                    7.7s 

          [+] Running 4/4
           ✔ Network openmower_default  Created  0.2s 
           ✔ Container OpenMowerApp     Started  6.8s 
           ✔ Container Mosquitto        Started  6.6s 
           ✔ Container open_mower_ros   Started  1.1s 
```
- WebApp
  - http://\<myhostname\>:8080/
  - works, but shows „UNKNOWN VERSION“ in menu bar on the left ⇒ I opened a ticket for this: https://github.com/ClemensElflein/open_mower_ros/issues/248
- configure parameters: `openmower configure ros`
  - left `bind_ip: "172.16.78.1"` unchanged, guess only applies for HWv2
  - changed `datum_lat` and `datum_long` to my coordinates
  - left NTRIP config unchanged, I don't use NTRIP and gps-rtk works for me, although it's not switched off explicitly (I will check the logs later)
  - changed the existing values in the yaml to my old values
  - after saving the file the container gets restarted automatically
- map:  I did not record a map, but copied my existing one from my OSv1 installation (`scp map.bag openmower@<myhostname>:ros/` and `scp checkpoint.bag openmower@<myhostname>:ros/`)
- restarted the container in dockge,  tests with the mower worked

### Comments on some points/results in the test matrix

- _Auto-reboot after initial boot_: don't know if it rebooted, but it worked without manual action => ok for me
- _SSH enabled_: as set in imager
- _Internal LAN_: I guess that does not apply for HWv1 => --
- _ESC access_: I did not check the correct motor, but I successfully connected each with VESC-Tool and the tool did the following mapping
  - right: ttyAMA3
  - mower: ttyAMA4
  - left: ttyAMA5
- _GNSS access_:  `openmower expose-gps 921600` worked, but only if the container is stopped (I guess this is normal)
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the hardware compatibility matrix reflecting test status changes across Raspberry Pi 4, Compute Module 4, and Compute Module 5 variants. Multiple features now show improved pass rates, including boot configuration, SSH enablement, Wi-Fi setup, and container access functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->