### PR TITLE
chore: Update TESTED_FEATURES.md

### DIFF
--- a/TESTED_FEATURES.md
+++ b/TESTED_FEATURES.md
@@ -7,23 +7,23 @@ Legend: ✅ Pass · ❌ Fail · 🟡 Todo · 🔁 Retry · 🧪 Manual-only
 | Auto-reboot after initial boot           | yes                                           |      ✅       |      ✅       |      ✅       |
 | Debian release `lsb_release -a`          | Debian GNU/Linux 13 (trixie)                  |      ✅       |      ✅       |      ✅       |
 | OpenMowerOS release `cat /etc/rpi-issue` | OpenMowerOS v2.x YYYY-MM-DD                   |      ✅       |      ✅       |      ✅       |
-| Hostname (default) `hostname`            | openmower                                     |      🟡       |      ✅       |      ✅       |
+| Hostname (default) `hostname`            | openmower                                     |      ✅       |      ✅       |      ✅       |
 | Hostname (non-default) `hostname`        | <as set by Raspberry Pi Imager v1.9.x>        |      ✅       |      ✅       |      ✅       |
-| Default user/password                    | openmower/openmower                           |      🟡       |      ✅       |      ✅       |
+| Default user/password                    | openmower/openmower                           |      ✅       |      ✅       |      ✅       |
 | SSH enabled                              | SSH active on first boot                      |      ✅       |      ✅       |      ✅       |
-| SSH public key                           | Password less SSH login via SSH-key           |      🟡       |      ✅       |      ✅       |
+| SSH public key                           | Password less SSH login via SSH-key           |      ✅       |      ✅       |      ✅       |
 | Imager Wi‑Fi                             | Preseeded Wi‑Fi connects on first boot        |      ✅       |      ✅       |      ✅       |
 | Imager openmower pass                    | Applied when configured                       |      ✅       |      ✅       |      ✅       |
-| No known Wi‑Fi                           | Comitup AP appears (default SSID pattern)     |      🟡       |      ✅       |      ✅       |
-| Comitup captive portal                   | Able to configure Wi‑Fi, then joins WLAN [^1] |      🟡       |      ✅       |      ✅       |
-| Internal LAN                             | xCore is getting an IPv4                      |      🟡       |      ✅       |      ✅       |
-| Home LAN                                 | eth0 IPv4 by your networks DHCP               |      🟡       |      ✅       |      ✅       |
+| No known Wi‑Fi                           | Comitup AP appears (default SSID pattern)     |      ✅       |      ✅       |      ✅       |
+| Comitup captive portal                   | Able to configure Wi‑Fi, then joins WLAN [^1] |      ✅       |      ✅       |      ✅       |
+| Internal LAN                             | xCore is getting an IPv4                      |      --       |      ✅       |      ✅       |
+| Home LAN                                 | eth0 IPv4 by your networks DHCP               |      ✅       |      ✅       |      ✅       |
 | SSH                                      | Reachable after network is up                 |      ✅       |      ✅       |      ✅       |
 | WebTerminal (ttyd)                       | Reachable at port 7681                        |      ✅       |      ✅       |      ✅       |
 | Dockge                                   | Reachable at port 5001                        |      ✅       |      ✅       |      ✅       |
 | ESC access                               | Ports get exposed via `openmower ...` cmd     |      ✅       |      ✅       |      🟡       |
 | GNSS access                              | Port get exposed via `openmower ...` cmd      |      ✅       |      🟡       |      🟡       |
-| OpenOCD remote debugging                 | Remote debugging via `openmower openocd`      |      🟡       |      ✅       |      ✅       |
+| OpenOCD remote debugging                 | Remote debugging via `openmower openocd`      |      ✅       |      ✅       |      ✅       |
 | Container shell (prefix)                 | `openmower shell` has docker prefix           |      ✅       |      ✅       |      ✅       |
 
 ## Notes


### PR DESCRIPTION
Tested the remaining todo-items for HW-V1 and updated the test matrix according to the following test scenario

### Environment

- HWv1
- OSv2 (OpenMowerOS_20260203.img)
- open_mower_ros: latest (v1.1.0)
- Yard Force Classic 500 with mainboard 0_11_X_WT901
- no NTRIP usage

### Test scenarios

#### Test 1: only image defaults

- Hostname (default) was `openmower` => ok
- Default user/password was openmower/openmower => ok
- Comitup AP appeared and was able to configure my WLAN => ok
- I think internal LAN does not apply for HWv1 so I set "--" 
- connected a LAN cable to the RasPi and got an IP-address, browser connection with it works => ok
- I have no experience with OpenOCD debugging but I did the following
  - `openmower openocd`
  - Telnet Connection on Port 4444: Prompt `Open On-Chip Debugger`
  - `targets`: 
    ```
    TargetName         Type       Endian TapName            State
    --  ------------------ ---------- ------ ------------------ ------------
     0* rp2040.core0       cortex_m   little rp2040.cpu         halted
     1  rp2040.core1       cortex_m   little rp2040.cpu         halted
    ```
  - `reset halt`:
    ```
    [rp2040.core0] halted due to debug-request, current mode: Thread
    xPSR: 0xf1000000 pc: 0x000000ea msp: 0x20041f00
    [rp2040.core1] halted due to debug-request, current mode: Thread
    xPSR: 0xf1000000 pc: 0x000000ea msp: 0x20041f00
    ```
  - `resume` yields the start audio message
  I guess openOCD debugging works as well => ok

#### Test 2: set ssh key in imager

- SSH session without password promt (for user `openmower`) works => ok
- I also switched off the wifi to see if the Comitup AP re-appears - and it did as expected => ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing status matrix to reflect expanded feature coverage across hardware variants, including hostname defaults, authentication options, SSH public key support, and remote debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->