### PR TITLE
Update default docking_extra_time

### DIFF
--- a/stage-openmower/40-openmower/files/home/openmower/params/mower_params.yaml
+++ b/stage-openmower/40-openmower/files/home/openmower/params/mower_params.yaml
@@ -24,7 +24,8 @@ ntrip_client:
 mower_logic:
   automatic_mode: 0
   docking_approach_distance: 1.0
-  docking_extra_time: 1.0
+  # Increase if necessary in small increments (e.g 0.1s) to ensure mower gets good contact on charging pins
+  docking_extra_time: 0.0
   docking_retry_count: 3
   docking_redock: false
   outline_overlap_count: 1


### PR DESCRIPTION
This is the extra time to drive after detecting voltage to ensure the mower fully engages on the docking pins.
Typically this should be a couple of hundred ms at most, default is 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added on-screen guidance for docking timing: you can increase the extra docking delay in small increments (for example, `0.1s`) to improve reliable contact with the charging pins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->